### PR TITLE
fix styling for background-image

### DIFF
--- a/templates/weather.html.twig
+++ b/templates/weather.html.twig
@@ -8,7 +8,7 @@
         <i class="fas fa-cloud-sun-rain"></i> Current weather by Wttr.in
     </div>
     <div class="image card-img-top"
-         style="{{ background }} height: 200px; padding-top: 60px;">
+         style="{{ background }} height: 200px; padding-top: 60px; background-size: cover; background-position: center center;">
         <center style='text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.6); color: #FFF;'>
             <span style="font-size: 175%; line-height: 1.75rem;">{{ weather.0 }} {{ weather.1 }} {{ weather.3 }}</span><br>
             <span style="font-size: 100%;">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9105243/99111176-ee456680-25eb-11eb-9f6c-523567f27391.png)

As you can see in the screenshot above the provided background-images from unsplash.com are not always correctly proportional to the available space in the div.

Therefore I added some inline CSS which should fix that problem.